### PR TITLE
Fix missing IP arg for submitToList

### DIFF
--- a/includes/class-emfi-config.php
+++ b/includes/class-emfi-config.php
@@ -128,7 +128,14 @@ class EmfiConfig {
 
 	}
 
-	public static function submitToList( string $list_uid, array $data , $ip_address) : void {
+       /**
+        * Submit mapped form data to a specific Etchmail list.
+        *
+        * @param string      $list_uid    Target list UID.
+        * @param array       $data        Array of mapped fields.
+        * @param string|null $ip_address  Optional originating IP address.
+        */
+       public static function submitToList( string $list_uid, array $data, ?string $ip_address = null ) : void {
 
 		/* 1. Gather the mapped fields ------------------------------------ */
 		$body   = [];     // final multipart payload

--- a/integrations/cf7/main.php
+++ b/integrations/cf7/main.php
@@ -262,8 +262,8 @@ class EMFI_CF7 {
 			];
 		}
 
-		/* -------- Call the helper -------- */
-		EmfiConfig::submitToList( $list_uid, $payload );
+               /* -------- Call the helper -------- */
+               EmfiConfig::submitToList( $list_uid, $payload, $_SERVER['REMOTE_ADDR'] ?? null );
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow `submitToList` to omit the IP address parameter
- send the visitor IP when submitting via the CF7 integration

## Testing
- `php -l includes/class-emfi-config.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859474f007083258f865510ede3e09f