### PR TITLE
Fix plugin validation errors

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -54,13 +54,15 @@ class Emfi_Admin_Settings {
 			return;
 		}
 
-		if ( $response && isset( $response['status'] ) && $response['status'] === 'success' ) {
-			wp_send_json_success( 'Connection successful!' );
-		} else {
-			// Log full failure response
-			error_log('Etchmail API failed: ' . json_encode($response));
-			wp_send_json_error( 'Connection failed. Please check your API settings.' );
-		}
+                if ( $response && isset( $response['status'] ) && $response['status'] === 'success' ) {
+                        wp_send_json_success( 'Connection successful!' );
+                } else {
+                        // Log full failure response when debugging
+                        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                                error_log( 'Etchmail API failed: ' . json_encode( $response ) );
+                        }
+                        wp_send_json_error( 'Connection failed. Please check your API settings.' );
+                }
 	}
 }
 

--- a/includes/class-emfi-config.php
+++ b/includes/class-emfi-config.php
@@ -206,14 +206,17 @@ class EmfiConfig {
 			$body[ $tag ] = $value;       // FNAME, LNAME, custom tags …
 		}
 
-		if ( $email === '' ) {
-			error_log( '[Etchmail] skipped – no email address found.' );
-			return;
-		}
+                if ( $email === '' ) {
+                        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                                error_log( '[Etchmail] skipped – no email address found.' );
+                        }
+                        return;
+                }
 
 		$body['EMAIL']               = $email;          // Etchmail’s required field
 		$body['details[source]']     = 'web';     // flat “details[…]” key
-		$body['details[ip_address]'] = $ip_address ?? $_SERVER['REMOTE_ADDR'];
+                $server_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+                $body['details[ip_address]'] = $ip_address ?: $server_ip;
 
 		/* 2. Hit the endpoint ------------------------------------------- */
 
@@ -230,8 +233,10 @@ class EmfiConfig {
 				return;
 			}
 
-			error_log( '[Etchmail] API error: ' . wp_json_encode( $resp ) );
-		}
+                        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                                error_log( '[Etchmail] API error: ' . wp_json_encode( $resp ) );
+                        }
+                }
 	}
 
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5,10 +5,12 @@ function emfi_api_v2_request( string $method, string $endpoint, array $body = []
 
 	$config = $config ?: EmfiConfig::all();
 
-	if ( empty( $config['api_url'] ) || empty( $config['api_key'] ) ) {
-		error_log( 'Etchmail API: Config missing or incomplete' );
-		return false;
-	}
+        if ( empty( $config['api_url'] ) || empty( $config['api_key'] ) ) {
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log( 'Etchmail API: Config missing or incomplete' );
+                }
+                return false;
+        }
 
         /* NOTE: no Content-Type header – WP will add the multipart boundary */
         $args = [
@@ -24,9 +26,11 @@ function emfi_api_v2_request( string $method, string $endpoint, array $body = []
         $endpoint = esc_url_raw( $endpoint );
         $resp = wp_remote_request( $endpoint, $args );
 
-	if ( is_wp_error( $resp ) ) {
-		error_log( 'Etchmail API error: ' . $resp->get_error_message() );
-		return false;
-	}
+        if ( is_wp_error( $resp ) ) {
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log( 'Etchmail API error: ' . $resp->get_error_message() );
+                }
+                return false;
+        }
 	return json_decode( wp_remote_retrieve_body( $resp ), true );
 }

--- a/integrations/cf7/assets/view.php
+++ b/integrations/cf7/assets/view.php
@@ -36,11 +36,6 @@ echo '<script>window.emfiCompat = ' .
     <div id="emfi-notice" style="display:none;margin-top:15px;"></div>
 
 
-    <!--    <div class="etchmail-header">-->
-    <!--       <img src="" alt="Etchmail" class="etchmail-logo">-->
-    <!--        <h2>Etchmail Integration</h2>-->
-    <!--        <p class="description">Connect this form to your Etchmail mailing list</p>-->
-    <!--    </div>-->
 
     <div class="etchmail-card">
         <div class="etchmail-card-header">
@@ -87,11 +82,11 @@ echo '<script>window.emfiCompat = ' .
 						}
 					}
 
-					if ( empty( $required_fields ) ) {
-						echo 'None';
-					} else {
-						echo implode( ', ', $required_fields );
-					}
+                                        if ( empty( $required_fields ) ) {
+                                                echo 'None';
+                                        } else {
+                                                echo esc_html( implode( ', ', $required_fields ) );
+                                        }
 					?>
                 </p>
 
@@ -179,7 +174,7 @@ echo '<script>window.emfiCompat = ' .
         const $loadLists = $('#load-etchmail-lists');
         const $saveBtn = $('#save-emfi-settings');
         const formId = <?php echo (int) $formid; ?>;
-        const nonce = '<?php echo wp_create_nonce( 'etchmail_nonce' ); ?>';
+        const nonce = '<?php echo esc_js( wp_create_nonce( 'etchmail_nonce' ) ); ?>';
 
         /* PHP → JS data blobs */
         let list_fields = <?php echo wp_json_encode( $this->list_fields ); ?>;

--- a/integrations/cf7/main.php
+++ b/integrations/cf7/main.php
@@ -76,9 +76,13 @@ class EMFI_CF7 {
 			return;
 		}
 
-		foreach ( self::$fields as $key => $field ) {
-			register_setting( 'EMFI_CF7', "emfi_cf7_{$this->form->id}_{$key}" );
-		}
+                foreach ( self::$fields as $key => $field ) {
+                        register_setting(
+                                'EMFI_CF7',
+                                "emfi_cf7_{$this->form->id}_{$key}",
+                                [ 'sanitize_callback' => 'sanitize_text_field' ]
+                        );
+                }
 
 		$this->enabled       = get_option( "emfi_cf7_{$this->form->id}_enabled", '0' );
 		$this->list_uid      = get_option( "emfi_cf7_{$this->form->id}_list_uid", '' );
@@ -87,15 +91,13 @@ class EMFI_CF7 {
 			$this->mapped_fields = [];
 		}
 
-		if ( $this->debug ) {
-			echo '<pre>';
-			var_dump( [
-				'enabled'       => $this->enabled,
-				'list_uid'      => $this->list_uid,
-				'mapped_fields' => $this->mapped_fields,
-			] );
-			echo '</pre>';
-		}
+                if ( $this->debug && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log( print_r( [
+                                'enabled'       => $this->enabled,
+                                'list_uid'      => $this->list_uid,
+                                'mapped_fields' => $this->mapped_fields,
+                        ], true ) );
+                }
 	}
 
 	/* ============================  AJAX  =============================== */
@@ -263,8 +265,9 @@ class EMFI_CF7 {
 		}
 
                /* -------- Call the helper -------- */
-               EmfiConfig::submitToList( $list_uid, $payload, $_SERVER['REMOTE_ADDR'] ?? null );
-	}
+               $ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+               EmfiConfig::submitToList( $list_uid, $payload, $ip );
+       }
 }
 
 new EMFI_CF7();

--- a/integrations/formidable/assets/view.php
+++ b/integrations/formidable/assets/view.php
@@ -80,11 +80,11 @@ echo '<script>window.emfiCompat = ' .
 						}
 					}
 
-					if ( empty( $required_fields ) ) {
-						echo 'None';
-					} else {
-						echo implode( ', ', $required_fields );
-					}
+                                        if ( empty( $required_fields ) ) {
+                                                echo 'None';
+                                        } else {
+                                                echo esc_html( implode( ', ', $required_fields ) );
+                                        }
 					?>
 				</p>
 
@@ -172,7 +172,7 @@ echo '<script>window.emfiCompat = ' .
         const $loadLists = $('#load-etchmail-lists');
         const $saveBtn = $('#save-emfi-settings');
         const formId = <?php echo (int) $formid; ?>;
-        const nonce = '<?php echo wp_create_nonce( 'etchmail_nonce' ); ?>';
+        const nonce = '<?php echo esc_js( wp_create_nonce( 'etchmail_nonce' ) ); ?>';
 
         /* PHP → JS data blobs */
         let list_fields = <?php echo wp_json_encode( $this->list_fields ); ?>;

--- a/integrations/formidable/main.php
+++ b/integrations/formidable/main.php
@@ -79,9 +79,13 @@ class EMFI_Formidable {
 			return;
 		}
 
-		foreach ( self::$fields as $key => $field ) {
-			register_setting( 'EMFI_FRM', "emfi_frm_{$this->form['id']}_{$key}" );
-		}
+                foreach ( self::$fields as $key => $field ) {
+                        register_setting(
+                                'EMFI_FRM',
+                                "emfi_frm_{$this->form['id']}_{$key}",
+                                [ 'sanitize_callback' => 'sanitize_text_field' ]
+                        );
+                }
 
 		$this->enabled       = get_option( "emfi_frm_{$this->form['id']}_enabled", '0' );
 		$this->list_uid      = get_option( "emfi_frm_{$this->form['id']}_list_uid", '' );
@@ -90,15 +94,13 @@ class EMFI_Formidable {
 			$this->mapped_fields = [];
 		}
 
-		if ( $this->debug ) {
-			echo '<pre>';
-			var_dump( [
-				'enabled'       => $this->enabled,
-				'list_uid'      => $this->list_uid,
-				'mapped_fields' => $this->mapped_fields,
-			] );
-			echo '</pre>';
-		}
+                if ( $this->debug && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log( print_r( [
+                                'enabled'       => $this->enabled,
+                                'list_uid'      => $this->list_uid,
+                                'mapped_fields' => $this->mapped_fields,
+                        ], true ) );
+                }
 	}
 
 
@@ -296,8 +298,9 @@ class EMFI_Formidable {
 			];
 		}
 
-		EmfiConfig::submitToList( $list_uid, $payload, $entry->ip );
-	}
+                $ip = sanitize_text_field( $entry->ip );
+                EmfiConfig::submitToList( $list_uid, $payload, $ip );
+        }
 }
 
 new EMFI_Formidable();

--- a/load.php
+++ b/load.php
@@ -7,17 +7,21 @@ require_once (EMFI_PLUGIN_DIR . 'admin/settings.php');
 
 // Run integration only if the selected plugin is enabled and available
 add_action('plugins_loaded', function () {
-	if (!class_exists('EmfiConfig')) {
-		error_log('Etchmail: Emfi_Config not loaded.');
-		return;
-	}
+        if ( ! class_exists( 'EmfiConfig' ) ) {
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log( 'Etchmail: Emfi_Config not loaded.' );
+                }
+                return;
+        }
 
 	$enabled = EmfiConfig::get('enabled_form');
 
-	if (!$enabled) {
-		error_log('Etchmail: No form integration selected.');
-		return;
-	}
+        if ( ! $enabled ) {
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log( 'Etchmail: No form integration selected.' );
+                }
+                return;
+        }
 
 	// check if the dependency is enabled.
 	$plugin_ready = match ($enabled) {
@@ -32,18 +36,22 @@ add_action('plugins_loaded', function () {
 		return; // disables the loading
 	}
 
-	if (!$plugin_ready) {
-		error_log("Etchmail: {$enabled} Integration could not be loaded.");
-		return;
-	}
+        if ( ! $plugin_ready ) {
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log( "Etchmail: {$enabled} Integration could not be loaded." );
+                }
+                return;
+        }
 
 
 	// Load the correct integration file
 	$integration_file = plugin_dir_path(__FILE__) . "integrations/{$enabled}/main.php";
 
-	if (file_exists($integration_file)) {
-		require_once $integration_file;
-	} else {
-		error_log("Etchmail: Integration file for [$enabled] not found.");
-	}
+        if ( file_exists( $integration_file ) ) {
+                require_once $integration_file;
+        } else {
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log( "Etchmail: Integration file for [$enabled] not found." );
+                }
+        }
 });

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: thewickettk
 Donate link: https://etchmail.com/contact
 Tags: etchmail, forms, integration, email-marketing, contact form 7, formidable forms, fluent forms
 Requires at least: 5.2
-Tested up to: 6.5.3
+Tested up to: 6.8
 Requires PHP: 8.2
 Stable tag: 1.0.0
 License: GPL-3.0

--- a/wp-etchmail-forms.php
+++ b/wp-etchmail-forms.php
@@ -1,6 +1,6 @@
 <?php defined('ABSPATH') || exit; // wp-etchmail-forms.php
 /**
- * Plugin Name: Etchmail Contact Form Integration
+ * Plugin Name: Etchmail Form Integration
  * Plugin URI: https://github.com/Etchmail/wp-form-integration
  * Description: Etchmail signup form integrations
  * Version: 1.0.0


### PR DESCRIPTION
## Summary
- update plugin name and WP version info
- clean up output escaping and unused image markup
- add sanitize callbacks for register_setting
- escape nonce values in JS
- wrap debug output and logs in WP_DEBUG checks
- sanitize IP addresses before use

## Testing
- `php -l wp-etchmail-forms.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a637856588325a984074ef5c8b0f1